### PR TITLE
use From trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ impl From<u8> for SamplingFrequency {
             0xd => SamplingFrequency::FreqReserved0xd,
             0xe => SamplingFrequency::FreqReserved0xe,
             0xf => SamplingFrequency::FreqReserved0xf,
-            _ => panic!("invalud value {:x}", value),
+            _ => panic!("invalid value {:#x} when parsing SamplingFrequency, expected a 4 bit value", value),
         }
     }
 }
@@ -181,7 +181,7 @@ impl From<u8> for ChannelConfiguration {
             0x5 => ChannelConfiguration::Five,
             0x6 => ChannelConfiguration::FiveOne,
             0x7 => ChannelConfiguration::SevenOne,
-            _ => panic!("invalid value {}", value),
+            _ => panic!("invalid value {:#x} when parsing ChannelConfiguration, expected a 3 bit value", value),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ pub enum SamplingFrequency {
     FreqReserved0xf = 0xf,
 }
 
-impl SamplingFrequency {
+impl From<u8> for SamplingFrequency {
     fn from(value: u8) -> SamplingFrequency {
         match value {
             0x0 => SamplingFrequency::Freq96000,
@@ -134,7 +134,9 @@ impl SamplingFrequency {
             _ => panic!("invalud value {:x}", value),
         }
     }
+}
 
+impl SamplingFrequency {
     pub fn freq(&self) -> Option<u32> {
         match self {
             &SamplingFrequency::Freq96000 => Some(96000),
@@ -168,7 +170,7 @@ pub enum ChannelConfiguration {
     FiveOne = 0x6,
     SevenOne = 0x7,
 }
-impl ChannelConfiguration {
+impl From<u8> for ChannelConfiguration {
     fn from(value: u8) -> ChannelConfiguration {
         match value {
             0x0 => ChannelConfiguration::ObjectTypeSpecificConfig,


### PR DESCRIPTION
My compiler complained that `SamplingFrequency::from()` only expected `enum syntax::adts_reader::SamplingFrequency` and not `u8`. This is solved by moving the `from(value: u8)` functions into the `std::convert::From<u8>` trait, so that the compiler doesn't get confused which `from` function to used.

I did consider using `std::convert::TryFrom` instead of `From`, which will allow the error be recoverable. However, I wasn't sure what error to return in `try_from`, whether additional variant is needed in `AdtsHeaderError`. And I wasn't sure that would be useful, as all cases should be already covered in the `match`, provided that the input value is sanitized (bitmasked). The panic messages are made more verbose to reflect that.